### PR TITLE
Minor bugfixes

### DIFF
--- a/src/main/java/au/org/ala/images/metadata/MP3MetadataParser.java
+++ b/src/main/java/au/org/ala/images/metadata/MP3MetadataParser.java
@@ -36,7 +36,9 @@ public class MP3MetadataParser extends AbstractMetadataParser {
 
     @Override
     public void extractMetadata(InputStream unopenedStream, Map<String, String> md) {
-        try(InputStream input = unopenedStream) {
+        // Do not close the provided stream here; the caller owns the lifecycle.
+        InputStream input = unopenedStream;
+        try {
             ContentHandler handler = new DefaultHandler();
             Metadata metadata = new Metadata();
             Parser parser = new Mp3Parser();
@@ -50,8 +52,6 @@ public class MP3MetadataParser extends AbstractMetadataParser {
                 md.put(name, metadata.get(name));
             }
 
-            // Consume the input stream to avoid resource leaks
-            IOUtils.consume(input);
         } catch (Exception e) {
             log.error("Exception extracting MP3 metadata", e);
         }

--- a/src/main/java/au/org/ala/images/metadata/MP4MetadataExtractor.java
+++ b/src/main/java/au/org/ala/images/metadata/MP4MetadataExtractor.java
@@ -32,7 +32,9 @@ public class MP4MetadataExtractor extends AbstractMetadataParser {
 
     @Override
     public void extractMetadata(InputStream unopenedStream, Map<String, String> md) {
-        try(InputStream input = unopenedStream) {
+        // Do not close the provided stream here; the caller owns the lifecycle.
+        InputStream input = unopenedStream;
+        try {
             ContentHandler handler = new DefaultHandler();
             Metadata metadata = new Metadata();
             Parser parser = new MP4Parser();
@@ -45,9 +47,6 @@ public class MP4MetadataExtractor extends AbstractMetadataParser {
             for(String name : metadataNames) {
                 md.put(name, metadata.get(name));
             }
-
-            // Consume the input stream to avoid resource leaks
-            IOUtils.consume(input);
 
         } catch (Exception e) {
             log.error("Exception extracting MP4 metadata", e);

--- a/src/main/java/au/org/ala/images/metadata/MetadataExtractor.java
+++ b/src/main/java/au/org/ala/images/metadata/MetadataExtractor.java
@@ -78,11 +78,15 @@ public class MetadataExtractor {
         try (BufferedInputStream bis = inputStream instanceof BufferedInputStream ?
                 (BufferedInputStream) inputStream :
                 new BufferedInputStream(inputStream)) {
+            // Mark the stream before content type detection so we can reset it for the parser
+            // Choose a reasonable upper bound for sniffing; 64KB should cover most detectors
+            bis.mark(64 * 1024);
             String contentType = detectContentTypeInternal(bis, filename);
             if (StringUtils.isNotEmpty(contentType)) {
                 for (AbstractMetadataParser p : _REGISTRY) {
                     Matcher m = p.getContentTypePattern().matcher(contentType);
                     if (m.matches()) {
+                        // Reset to the mark so the parser sees the stream from the beginning
                         bis.reset();
                         p.extractMetadata(bis, map);
                         break;

--- a/src/main/java/au/org/ala/images/tiling/ImageTilerResults.java
+++ b/src/main/java/au/org/ala/images/tiling/ImageTilerResults.java
@@ -26,6 +26,10 @@ public class ImageTilerResults {
         return _success;
     }
 
-
-
+    @Override
+    public String toString() {
+        return "ImageTilerResults{_success=" + _success +
+                ", _zoomLevels=" + _zoomLevels +
+                '}';
+    }
 }

--- a/src/test/java/au/org/ala/images/tiling/ImageTilerTest.java
+++ b/src/test/java/au/org/ala/images/tiling/ImageTilerTest.java
@@ -61,7 +61,7 @@ public class ImageTilerTest extends TestBase {
         File imageFile = new File(url.toURI());
 
         ImageTilerConfig config = new ImageTilerConfig();
-        ImageTiler tiler = new ImageTiler(config);
+        ImageTiler3 tiler = new ImageTiler3(config);
 
         Path tempDir = Files.createTempDirectory("imagetests");
         try {


### PR DESCRIPTION
- Use ImageTiler3 in unit test
- Don't double close streams in MP3 and MP4 metadata parsers
- Add toString to ImageTilerResult
- Add missing mark call before reset to MetadataExtractor